### PR TITLE
Update layout.user.php

### DIFF
--- a/core/templates/layout.user.php
+++ b/core/templates/layout.user.php
@@ -71,7 +71,7 @@
 					<?php endforeach; ?>
 					<li id="more-apps" class="menutoggle">
 						<a href="#">
-							<div class="icon-more-white"></div>
+							<div class="icon-more"></div>
 							<span><?php p($l->t('More apps')); ?></span>
 						</a>
 					</li>


### PR DESCRIPTION
The icon for more apps was set to always be white, which didn't respect having a contrast on lighter colours.
Changed it to the generic "icon-more" class so it can be seen on light backgrounds.

Signed-off-by: Matthew Stobbs <matthew@sproutingcommunications.com>